### PR TITLE
[don't merge] Create a tag based on new stable Debian (stretch)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6-stretch
 LABEL maintainer "info@camptocamp.org"
 
 RUN wget http://download.osgeo.org/gdal/2.2.2/gdal-2.2.2.tar.gz --output-document=/tmp/gdal.tar.gz && \


### PR DESCRIPTION
Stretch is the new stable version of Debian.
Additionnally, this version fixes the issue with RFC 3484 rule 9 and DNS roundrobin.